### PR TITLE
Support ECS Exec

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,6 +48,7 @@ No modules.
 | [aws_efs_mount_target.minecraft_ondemand_efs_mount_target_c](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_iam_policy.backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.minecraft_ondemand_ecs_control_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.minecraft_ondemand_ecs_exec_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.minecraft_ondemand_efs_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.minecraft_ondemand_route53_update_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.minecraft_ondemand_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -58,6 +59,7 @@ No modules.
 | [aws_iam_role_policy_attachment.ecs_task_exec_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minecraft_ondemand_ecs_control_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minecraft_ondemand_ecs_control_policy_attachment_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.minecraft_ondemand_ecs_exec_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minecraft_ondemand_efs_access_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minecraft_ondemand_lambda_cloudwatch_logging_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.minecraft_ondemand_route53_update_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -107,6 +107,7 @@ resource "aws_ecs_service" "minecraft_ondemand_service" {
   desired_count   = 0
   #   iam_role        = aws_iam_role.minecraft_ondemand_fargate_task_role.arn
   depends_on = [aws_iam_policy.minecraft_ondemand_efs_access_policy]
+  enable_execute_command = true
 
   capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -33,7 +33,7 @@ resource "aws_iam_role" "minecraft_ondemand_fargate_task_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
-      },
+      }
     ]
   })
   tags = var.common_tags
@@ -106,6 +106,33 @@ resource "aws_iam_policy" "minecraft_ondemand_ecs_control_policy" {
 resource "aws_iam_role_policy_attachment" "minecraft_ondemand_ecs_control_policy_attachment" {
   role       = aws_iam_role.minecraft_ondemand_fargate_task_role.name
   policy_arn = aws_iam_policy.minecraft_ondemand_ecs_control_policy.arn
+}
+
+resource "aws_iam_policy" "minecraft_ondemand_ecs_exec_policy" {
+  name        = "minecraft_ondemand_ecs_task_exec_policy"
+  path        = "/"
+  description = "Allows the Minecraft server ECS task to communicate with the SSM agent for ECS Exec"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ],
+        "Resource": "*"
+      }
+    ]
+  })
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "minecraft_ondemand_ecs_exec_policy_attachment" {
+  role       = aws_iam_role.minecraft_ondemand_fargate_task_role.name
+  policy_arn = aws_iam_policy.minecraft_ondemand_ecs_exec_policy.arn
 }
 
 resource "aws_iam_policy" "minecraft_ondemand_sns_publish_policy" {


### PR DESCRIPTION
Adds support for [ECS Exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html) as another way to configure the server/tail logs.